### PR TITLE
Neuprint route

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ TRANSFER_FUNC: the transfer network cloud run location.
 
 TRANSFER_DEST: the transfer network cache location.
 
+NEUPRINT_APPLICATION_CREDENTIALS: credentials to access neuprint
+
 ### Used during local testing or use outside of Cloud Run / Cloud Functions
 
 GOOGLE_APPLICATION_CREDENTIALS: set to credentials for app to access GCP services.

--- a/dependencies.py
+++ b/dependencies.py
@@ -1,6 +1,6 @@
 import time
 
-from fastapi import Depends, HTTPException, status
+from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 
 from google.auth.transport import requests
@@ -15,6 +15,9 @@ from config import *
 
 __DATASET_CACHE__ = None
 __USER_CACHE__ = None
+
+# stores reference to global APP
+app = FastAPI()
 
 # reloads User and Dataset info from DB after this many seconds
 USER_REFRESH_SECS = 600.0

--- a/main.py
+++ b/main.py
@@ -6,8 +6,6 @@ from config import URL_PREFIX
 from dependencies import get_user, app
 from services import annotations_v2, annotations_v1, atlas, datasets, image_query, image_transfer, kv, savedsearches, users, neuprint
 
-app = FastAPI()
-
 # Wire in the API endpoints
 # require user authorization for any of the actual data API calls
 # versions: "clio_toplevel" is v1, other versions are explicitly "v2", etc.
@@ -30,7 +28,6 @@ app.include_router(image_transfer.router, prefix=f"{URL_PREFIX}/v2/transfer", de
 app.include_router(kv.router, prefix=f"{URL_PREFIX}/v2/kv", dependencies=[Depends(get_user)])
 app.include_router(savedsearches.router, prefix=f"{URL_PREFIX}/v2/savedsearches", dependencies=[Depends(get_user)])
 app.include_router(users.router, prefix=f"{URL_PREFIX}/v2/users", dependencies=[Depends(get_user)])
->>>>>>> main
 
 # Handle CORS
 app.add_middleware(

--- a/main.py
+++ b/main.py
@@ -1,15 +1,14 @@
-from fastapi import Depends, FastAPI
+from fastapi import Depends
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 
-from dependencies import get_user
-from services import annotations, atlas, datasets, image_query, image_transfer, kv, savedsearches
-
-app = FastAPI()
+from dependencies import get_user, app
+from services import annotations, atlas, datasets, image_query, image_transfer, kv, savedsearches, neuprint
 
 # Wire in the API endpoints
 # require user authorization for any of the actual data API calls
 app.include_router(annotations.router, dependencies=[Depends(get_user)])
+app.include_router(neuprint.router, dependencies=[Depends(get_user)])
 app.include_router(atlas.router, dependencies=[Depends(get_user)])
 app.include_router(datasets.router, dependencies=[Depends(get_user)])
 app.include_router(image_query.router, dependencies=[Depends(get_user)])

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ typing-extensions==3.7.4.3
 urllib3==1.26.2
 uvicorn==0.13.1
 Werkzeug==1.0.1
+aiohttp==3.7.3

--- a/services/neuprint.py
+++ b/services/neuprint.py
@@ -10,9 +10,7 @@ NEUPRINT_CREDENTIALS = os.environ.get("NEUPRINT_APPLICATION_CREDENTIALS")
 # neuprint address (TODO: move configuration to be in the dataset)
 NEUPRINT_URL="https://neuprint.janelia.org/api/custom/custom"
 
-router = APIRouter(
-    prefix=f"{URL_PREFIX}/neuprint"
-)
+router = APIRouter()
 
 # create a persistent session for this service
 client_session = aiohttp.ClientSession()

--- a/services/neuprint.py
+++ b/services/neuprint.py
@@ -1,0 +1,48 @@
+from config import *
+from fastapi import APIRouter, Depends, HTTPException
+from dependencies import get_user, User, app
+import aiohttp 
+from pydantic import BaseModel
+
+# token for accessing neuprint
+NEUPRINT_CREDENTIALS = os.environ.get("NEUPRINT_APPLICATION_CREDENTIALS")
+
+# neuprint address (TODO: move configuration to be in the dataset)
+NEUPRINT_URL="https://neuprint.janelia.org/api/custom/custom"
+
+router = APIRouter(
+    prefix=f"{URL_PREFIX}/neuprint"
+)
+
+# create a persistent session for this service
+client_session = aiohttp.ClientSession()
+
+# accesses the global app to register a shutdown event
+@app.on_event("shutdown")
+async def cleanup():
+    await client_session.close()
+
+neuprint_headers = {
+    "Authorization": f"Bearer {NEUPRINT_CREDENTIALS}"
+}
+
+class NeuprintRequest(BaseModel):
+    """Request object for custom neuPrint requests.
+    """
+    cypher: str
+    dataset: str
+
+@router.post('/{dataset}')
+@router.post('/{dataset}/', include_in_schema=False)
+async def post_neuprint_custom(dataset: str, payload: NeuprintRequest, user: User = Depends(get_user)):
+    if not user.has_role("clio_general", dataset):
+        raise HTTPException(status_code=403, detail="user doesn't have authorization for this dataset")
+
+    try:
+        async with client_session.post(NEUPRINT_URL, data=dict(payload), headers=neuprint_headers) as resp:
+            response = await resp.json()
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=400, detail=f"error in neuprint request for dataset {dataset}")
+
+    return response


### PR DESCRIPTION
This adds a new route that forwards requests to Clio to neuprint.janelia.org.  For now, this implementation assumes that all neuprint databases are at neuprint.janelia.org.  Eventually, this information should be encoded in the dataset metadata, as there could be different servers for each dataset.

Note: to use this endpoint NEUPRINT_APPLICATION_CREDENTIALS should be set to some user token.  This probably should be some gmail created just to be used as a service account.  It doesn't matter as much now since neuprint.janelia.org only contains the hemibrain and it is set to be publicly readable independent of the user permission.

Note 2: There should be a version tag stored somewhere in the metadata as that is required when specifying a dataset in neuprint.