### PR TITLE
move to http/2 to remove limits on response sizes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM python:3.9-slim
-ENV APP_HOME /
+
+ENV APP_HOME /app
 WORKDIR $APP_HOME
+
+# Copy requirements first for better layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
 COPY . ./
-RUN pip install -r requirements.txt
-CMD exec uvicorn main:app --host=0.0.0.0 --port=$PORT
+
+# Use hypercorn instead of uvicorn for better HTTP/2 support
+CMD exec hypercorn main:app --bind 0.0.0.0:${PORT:-8080}

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ grpcio-status==1.51.1
 h11==0.14.0
 httpcore==0.16.2
 httpx==0.23.1
+hypercorn>=0.14.3
 idna==3.4
 multidict==6.0.2
 numpy==1.23.5


### PR DESCRIPTION
Update deployment to modern GCP workflow and upgrade service to http/2 to remove the 32 MiB response size limit. This was hit while using {"type": "exists/1"} query. @stuarteberg 